### PR TITLE
Add backend health check endpoint

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,3 +1,4 @@
+import { HealthModule } from './health/health.module';
 import { Module, ValidationPipe } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_PIPE } from '@nestjs/core';
@@ -20,6 +21,7 @@ import { PrismaService } from './prisma.service';
     PostsModule,
     AnalyticsModule,
     DashboardModule,
+    HealthModule,
   ],
   providers: [
     PrismaService,

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  check() {
+    return {
+      status: 'ok',
+      service: 'backend',
+      timestamp: new Date().toISOString(),
+    };
+  }
+}


### PR DESCRIPTION
Closes #6


### Summary
- Adds a /health endpoint to verify backend availability
- Introduces a lightweight HealthModule

### Why
- Makes backend startup easy to verify
- Helps contributors debug environment issues
- No breaking changes

### How to test
- Run backend
- Visit GET /health

